### PR TITLE
Remove htmlFor from Attributes

### DIFF
--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -17,7 +17,6 @@ var UNKNOWN_MESSAGE = 'Unknown property \'{{name}}\' found, use \'{{standardName
 var DOM_ATTRIBUTE_NAMES = {
   'accept-charset': 'acceptCharset',
   class: 'className',
-  for: 'htmlFor',
   'http-equiv': 'httpEquiv'
 };
 
@@ -115,7 +114,7 @@ var DOM_PROPERTY_NAMES = [
   'acceptCharset', 'accessKey', 'allowFullScreen', 'allowTransparency', 'autoComplete', 'autoFocus', 'autoPlay',
   'cellPadding', 'cellSpacing', 'charSet', 'classID', 'className', 'colSpan', 'contentEditable', 'contextMenu',
   'crossOrigin', 'dateTime', 'encType', 'formAction', 'formEncType', 'formMethod', 'formNoValidate', 'formTarget',
-  'frameBorder', 'hrefLang', 'htmlFor', 'httpEquiv', 'inputMode', 'keyParams', 'keyType', 'marginHeight', 'marginWidth',
+  'frameBorder', 'hrefLang', 'httpEquiv', 'inputMode', 'keyParams', 'keyType', 'marginHeight', 'marginWidth',
   'maxLength', 'mediaGroup', 'minLength', 'noValidate', 'onAnimationEnd', 'onAnimationIteration', 'onAnimationStart',
   'onBlur', 'onChange', 'onClick', 'onContextMenu', 'onCopy', 'onCompositionEnd', 'onCompositionStart',
   'onCompositionUpdate', 'onCut', 'onDoubleClick', 'onDrag', 'onDragEnd', 'onDragEnter', 'onDragExit', 'onDragLeave',

--- a/tests/lib/rules/no-unknown-property.js
+++ b/tests/lib/rules/no-unknown-property.js
@@ -48,11 +48,6 @@ ruleTester.run('no-unknown-property', rule, {
     errors: [{message: 'Unknown property \'class\' found, use \'className\' instead'}],
     parserOptions: parserOptions
   }, {
-    code: '<div for="bar"></div>;',
-    output: '<div htmlFor="bar"></div>;',
-    errors: [{message: 'Unknown property \'for\' found, use \'htmlFor\' instead'}],
-    parserOptions: parserOptions
-  }, {
     code: '<div accept-charset="bar"></div>;',
     output: '<div acceptCharset="bar"></div>;',
     errors: [{message: 'Unknown property \'accept-charset\' found, use \'acceptCharset\' instead'}],


### PR DESCRIPTION
Based on [#783](https://github.com/infernojs/inferno/issues/783) it looks like Inferno prefers `for` instead of `htmlFor` on Input labels. I removed the `htmlFor` cases from the eslint configuration to match.