### PR TITLE
Add support for state as render parameter

### DIFF
--- a/lib/rules/no-unused-state.js
+++ b/lib/rules/no-unused-state.js
@@ -174,6 +174,22 @@ module.exports = {
       }
     }
 
+    function handleInfernoMethod(node) {
+      if (node.key.name === 'render') {
+        const stateParam = node.value.params[1];
+        if (stateParam) {
+          if (stateParam.type === 'ObjectPattern') {
+            handleStateDestructuring(stateParam);
+          } else if (stateParam.type === 'Identifier') {
+            if (classInfo.aliases) {
+              classInfo.aliases.add(stateParam.name);
+            }
+          }
+        }
+      }
+    }
+
+
     return {
       ClassDeclaration(node) {
         if (utils.isES6Component(node)) {
@@ -261,6 +277,11 @@ module.exports = {
         }
 
         const parent = node.parent;
+
+        if (utils.isES5Component(parent.parent) || utils.isES6Component(parent.parent.parent)) {
+          handleInfernoMethod(parent);
+        }
+
         if (!utils.isES5Component(parent.parent)) {
           return;
         }

--- a/tests/lib/rules/no-unused-state.js
+++ b/tests/lib/rules/no-unused-state.js
@@ -137,6 +137,22 @@ eslintTester.run('no-unused-state', rule, {
         return <SomeComponent onClick={this.update} foo={this.state.foo} />;
       }
     });`,
+    `class StateInRenderTest extends Inferno.Component {
+      constructor() {
+        this.state = { 'foo': 0 };
+      }
+      render(props, state) {
+        return <SomeComponent foo={state.foo} />;
+      }
+    }`,
+    `class DestructuredStateInRenderTest extends Inferno.Component {
+      constructor() {
+        this.state = { 'foo': 0 };
+      }
+      render(props, { foo }) {
+        return <SomeComponent foo={foo} />;
+      }
+    }`,
     `class NoStateTest extends Inferno.Component {
       render() {
         return <SomeComponent />;


### PR DESCRIPTION
The new rule `no-unused-state` report unused state fields when state is used as parameter of the render method

```js
import Component from 'inferno-component';

export default class TestComponent extends Component {
  constructor(props, context) {
    super(props, context);
    this.state = {
      test: 'test',
    };
  }

  render(props, { state }) {
    return <div>{state}</div>;
  }
}
```
