### PR TITLE
Fixed fork note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ESLint-plugin-Inferno
 ===================
 
-Note: This is a fork of the great [eslint-plugin-inferno](https://github.com/yannickcr/eslint-plugin-inferno).
+Note: This is a fork of the great [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react).
 
 Inferno specific linting rules for ESLint
 Rules are mostly same, but propType related rules have been removed.


### PR DESCRIPTION
I fixed the readme to point to eslint-plugin-react, rather than the `non-existant yannickcr/eslint-plugin-inferno`.